### PR TITLE
Fix missing continue button in booking form

### DIFF
--- a/src/components/landing/Booking.tsx
+++ b/src/components/landing/Booking.tsx
@@ -444,6 +444,14 @@ const Booking = () => {
                           </div>
                         </div>
                       )}
+
+                      <Button
+                        onClick={handleContinue}
+                        disabled={!selectedService}
+                        className="w-full mt-8 bg-garden-primary hover:bg-garden-accent text-white text-lg p-6 rounded-xl transition-all duration-300 flex items-center justify-center gap-2 disabled:opacity-70 disabled:cursor-not-allowed">
+                        Weiter
+                        <ArrowRight className="w-5 h-5" />
+                      </Button>
                     </div>
                   ) : (
                     <div className="space-y-6">
@@ -659,15 +667,17 @@ const Booking = () => {
                       </div>
 
                       <Button
-                        onClick={handleContinue}
-                        disabled={isLoading}
-                        className="w-full bg-garden-primary hover:bg-garden-accent text-white">
+                        onClick={handleSubmit}
+                        disabled={isLoading || Object.keys(errors).length > 0}
+                        className="w-full mt-8 bg-garden-primary hover:bg-garden-accent text-white text-lg p-6 rounded-xl transition-all duration-300 flex items-center justify-center gap-2 disabled:opacity-70 disabled:cursor-not-allowed">
                         {isLoading ? (
-                          <LoadingDots />
+                          <div className="flex items-center gap-2">
+                            <LoadingDots />
+                          </div>
                         ) : (
                           <>
-                            Absenden
-                            <ArrowRight className="ml-2 h-5 w-5" />
+                            Anfrage senden
+                            <ArrowRight className="w-5 h-5" />
                           </>
                         )}
                       </Button>


### PR DESCRIPTION
# Fix missing continue button in booking form

## Description:
- Fixed the "Continue" button that disappeared in step 1 of the booking form
- Put the button back in its original position after service selection
- Kept all image upload functionality working
- Made sure both steps (service selection and contact form) work properly again

**The bug happened when we added image uploads and removed prices(#3 by @Belsetbut). This fix restores the button while keeping the new features.**