### PR TITLE
Fix: Prevent Overscrolling Past the Top of the Page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -77,3 +77,11 @@ html {
   scroll-behavior: smooth;
   scroll-padding-top: 100px;
 }
+
+
+html, body {
+  overscroll-behavior: none; 
+  margin: 0; 
+  padding: 0; 
+  height: 100%;
+}


### PR DESCRIPTION
## Description:
This PR resolves the issue of overscrolling beyond the top of the page, which caused a blank white space to appear. The fix includes:

- Adding overscroll-behavior: none to global styles.
- Ensuring proper layout structure with height: 100% on html and body elements.
- Adding a fallback JavaScript solution for edge cases (e.g., iOS Safari rubber-band scrolling).

## Changes Made:
Global CSS Changes:

- Added overscroll-behavior: none to html and body styles.
- Set height: 100% and removed margins/padding on body.


## Testing:
Tested across multiple Platforms  (Mac(Chrome), iOS(Safari)).
Verified behavior on mobile devices (iOS and Android).

Related Issue: #7 